### PR TITLE
Io error handling

### DIFF
--- a/com.zsmartsystems.bluetooth.bluegiga/src/main/java/com/zsmartsystems/bluetooth/bluegiga/BlueGigaHandlerListener.java
+++ b/com.zsmartsystems.bluetooth.bluegiga/src/main/java/com/zsmartsystems/bluetooth/bluegiga/BlueGigaHandlerListener.java
@@ -1,0 +1,18 @@
+package com.zsmartsystems.bluetooth.bluegiga;
+
+
+/**
+ * A lisener to track {@link BlueGigaSerialHandler} life cycle events.
+ *
+ * @author Chris Jackson
+ * @author Vlad Kolotov
+ */
+public interface BlueGigaHandlerListener {
+
+    /**
+     * Notifies when the handler gets closed because of the reason specified as an argument.
+     * @param reason a reason caused to be closed
+     */
+    void bluegigaClosed(Exception reason);
+
+}


### PR DESCRIPTION
Hi @cdjackson, please have a look what I've done to improve IO error handling. This is mainly to handle errors that normally occur with USB dongle when it disconnects or any other OS-specific things happen (e.g. when IO streams get closed/corrupted etc).

Basically, if something bad happens the BlugigaSerialHandler counts IO errors and then if the number of errors exceeds a threshold, then the main thread shuts down without notifying the handler clients. Furthermore, when the main thread completes, the handler continues accepting Bluegiga commands like if it was in "alive" state.

This PR addresses the issues above.