### PR TITLE
Handling IO timeout errors for write and read operations

### DIFF
--- a/com.zsmartsystems.bluetooth.bluegiga/src/main/java/com/zsmartsystems/bluetooth/bluegiga/BlueGigaException.java
+++ b/com.zsmartsystems.bluetooth.bluegiga/src/main/java/com/zsmartsystems/bluetooth/bluegiga/BlueGigaException.java
@@ -1,0 +1,19 @@
+package com.zsmartsystems.bluetooth.bluegiga;
+
+/**
+ * A generic BlueGiga exception.
+ */
+public class BlueGigaException extends RuntimeException {
+
+    public BlueGigaException() {
+        super();
+    }
+
+    public BlueGigaException(String message) {
+        super(message);
+    }
+
+    public BlueGigaException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Hi @cdjackson, further to the previous PR to improve error handling I have done some other improvements to make it even more robust.

Essentially, I've added a new method similar to sendTransaction but with a new argument that specifies how long the handler should wait until it times out. It can be used to detect stale serial ports.

Also, I've aded a generic exception (unchecked) that it used to signal that an unrecoverable error happened.

Thanks,
Vlad