### PR TITLE
Adding support for service data broadcasting

### DIFF
--- a/com.zsmartsystems.bluetooth.bluegiga/src/main/java/com/zsmartsystems/bluetooth/bluegiga/eir/EirRecord.java
+++ b/com.zsmartsystems.bluetooth.bluegiga/src/main/java/com/zsmartsystems/bluetooth/bluegiga/eir/EirRecord.java
@@ -121,23 +121,23 @@ public class EirRecord {
     }
 
     private UUID process16BitUUID(int[] data, int index) {
-        long high = ((long) data[index++] << 32) + ((long) data[index] << 40);
+        long high = ((long) data[index] << 32) + ((long) data[index + 1] << 40);
         return new UUID(high, 0);
     }
 
     private UUID process32BitUUID(int[] data, int index) {
-        long high = ((long) data[index++] << 32) + ((long) data[index++] << 40) + ((long) data[index++] << 48)
-                + ((long) data[index] << 56);
+        long high = ((long) data[index] << 32) + ((long) data[index + 1] << 40) + ((long) data[index + 2] << 48)
+                + ((long) data[index + 3] << 56);
         return new UUID(high, 0);
     }
 
     private UUID process128BitUUID(int[] data, int index) {
-        long low = (data[index++]) + ((long) data[index++] << 8) + ((long) data[index++] << 16)
-                + ((long) data[index++] << 24) + ((long) data[index++] << 32) + ((long) data[index++] << 40)
-                + ((long) data[index++] << 48) + ((long) data[index++] << 56);
-        long high = (data[index++]) + ((long) data[index++] << 8) + ((long) data[index++] << 16)
-                + ((long) data[index++] << 24) + ((long) data[index++] << 32) + ((long) data[index++] << 40)
-                + ((long) data[index++] << 48) + ((long) data[index] << 56);
+        long low = (data[index]) + ((long) data[index + 1] << 8) + ((long) data[index + 2] << 16)
+                + ((long) data[index + 3] << 24) + ((long) data[index + 4] << 32) + ((long) data[index + 5] << 40)
+                + ((long) data[index + 6] << 48) + ((long) data[index + 7] << 56);
+        long high = (data[index + 8]) + ((long) data[index + 9] << 8) + ((long) data[index + 10] << 16)
+                + ((long) data[index + 11] << 24) + ((long) data[index + 12] << 32) + ((long) data[index + 13] << 40)
+                + ((long) data[index + 14] << 48) + ((long) data[index + 15] << 56);
         return new UUID(high, low);
     }
 

--- a/com.zsmartsystems.bluetooth.bluegiga/src/test/java/com/zsmartsystems/bluetooth/bluegiga/eir/EirRecordTest.java
+++ b/com.zsmartsystems.bluetooth.bluegiga/src/test/java/com/zsmartsystems/bluetooth/bluegiga/eir/EirRecordTest.java
@@ -1,0 +1,114 @@
+package com.zsmartsystems.bluetooth.bluegiga.eir;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class EirRecordTest {
+
+    @Test
+    public void testProcess16BitUUIDs() {
+        int[] data = {0x03, 0x0F, 0x18, 0x00, 0x18};
+        String batteryService = "0000180f-0000-0000-0000-000000000000";
+        String genericAccess = "00001800-0000-0000-0000-000000000000";
+
+        EirRecord eirRecord = new EirRecord(data);
+        assertEquals(EirDataType.EIR_SVC_UUID16_COMPLETE, eirRecord.getType());
+        List<UUID> uuids = (List<UUID>) eirRecord.getRecord();
+        assertEquals(2, uuids.size());
+        assertTrue(uuids.contains(UUID.fromString(batteryService)));
+        assertTrue(uuids.contains(UUID.fromString(genericAccess)));
+    }
+
+    @Test
+    public void testProcess32BitUUIDs() {
+        int[] data = {0x05,
+                /* service1 */ 0x10, 0x8e, 0xe7, 0x74,
+                /* service2 */ 0x11, 0x8e, 0xe7, 0x64
+        };
+        String service1 = "74E78E10-0000-0000-0000-000000000000";
+        String service2 = "64E78E11-0000-0000-0000-000000000000";
+
+        EirRecord eirRecord = new EirRecord(data);
+        assertEquals(EirDataType.EIR_SVC_UUID32_COMPLETE, eirRecord.getType());
+        List<UUID> uuids = (List<UUID>) eirRecord.getRecord();
+        assertEquals(2, uuids.size());
+        assertTrue(uuids.contains(UUID.fromString(service1)));
+        assertTrue(uuids.contains(UUID.fromString(service2)));
+    }
+
+    @Test
+    public void testProcess128BitUUIDs() {
+        int[] data = {0x07,
+                /* service1 */ 0x6d, 0x66, 0x70, 0x44, 0x73, 0x66, 0x62, 0x75, 0x66, 0x45, 0x76, 0x64, 0x55, 0xaa, 0x6c, 0x22,
+                /* service2 */ 0x6e, 0x66, 0x70, 0x44, 0x73, 0x66, 0x62, 0x75, 0x66, 0x45, 0x76, 0x64, 0x55, 0xaa, 0x6c, 0x12,
+        };
+        String service1 = "226caa55-6476-4566-7562-66734470666d";
+        String service2 = "126caa55-6476-4566-7562-66734470666e";
+
+        EirRecord eirRecord = new EirRecord(data);
+        assertEquals(EirDataType.EIR_SVC_UUID128_COMPLETE, eirRecord.getType());
+        List<UUID> uuids = (List<UUID>) eirRecord.getRecord();
+        assertEquals(2, uuids.size());
+        assertTrue(uuids.contains(UUID.fromString(service1)));
+        assertTrue(uuids.contains(UUID.fromString(service2)));
+    }
+
+    @Test
+    public void testProcessManufacturerData() {
+        int[] data = {/* length 0x05,*/ 0xFF, 0xFF, 0x02, 0x00, 0xFF};
+        short siliconLabsID = (short) 0x02FF;
+
+        EirRecord eirRecord = new EirRecord(data);
+        assertEquals(EirDataType.EIR_MANUFACTURER_SPECIFIC, eirRecord.getType());
+        Map<Short, int[]> manufacturerData = (Map<Short, int[]>) eirRecord.getRecord();
+        assertTrue(manufacturerData.containsKey(siliconLabsID));
+        assertArrayEquals(new int[] {0x00, 0xFF}, manufacturerData.get(siliconLabsID));
+    }
+
+    @Test
+    public void testUUID16ServiceData() {
+        int[] data = {/* length 0x05,*/ /* service data 16 bit UUID*/ 0x16, 0x0F, 0x18, 0x45};
+        UUID batteryServiceUUID = UUID.fromString("0000180f-0000-0000-0000-000000000000");
+
+        EirRecord eirRecord = new EirRecord(data);
+        assertEquals(EirDataType.EIR_SVC_DATA_UUID16, eirRecord.getType());
+        Map<UUID, int[]> serviceData = (Map<UUID, int[]>) eirRecord.getRecord();
+        assertTrue(serviceData.containsKey(batteryServiceUUID));
+        assertArrayEquals(new int[] {0x45}, serviceData.get(batteryServiceUUID));
+    }
+
+    @Test
+    public void testUUID32ServiceData() {
+        int[] data = {
+                /* service data 32 bit UUID*/ 0x20,
+                /* UUID */ 0x10, 0x8e, 0xe7, 0x74,
+                /* data */ 0x74, 0x01, 0x0d, 0x01, (byte) 0xec};
+        UUID dataServiceUUID = UUID.fromString("74E78E10-0000-0000-0000-000000000000");
+
+        EirRecord eirRecord = new EirRecord(data);
+        assertEquals(EirDataType.EIR_SVC_DATA_UUID32, eirRecord.getType());
+        Map<UUID, int[]> serviceData = (Map<UUID, int[]>) eirRecord.getRecord();
+        assertTrue(serviceData.containsKey(dataServiceUUID));
+        assertArrayEquals(new int[] {0x74, 0x01, 0x0d, 0x01, (byte) 0xec}, serviceData.get(dataServiceUUID));
+    }
+
+    @Test
+    public void testUUID128ServiceData() {
+        int[] data = {
+                /* service data 32 bit UUID*/ 0x21,
+                /* UUID */ 0x6d, 0x66, 0x70, 0x44, 0x73, 0x66, 0x62, 0x75, 0x66, 0x45, 0x76, 0x64, 0x55, 0xaa, 0x6c, 0x22,
+                /* data */ 0x74, 0x01, 0x0d, 0x01, (byte) 0xec};
+        UUID dataServiceUUID = UUID.fromString("226caa55-6476-4566-7562-66734470666d");
+
+        EirRecord eirRecord = new EirRecord(data);
+        assertEquals(EirDataType.EIR_SVC_DATA_UUID128, eirRecord.getType());
+        Map<UUID, int[]> serviceData = (Map<UUID, int[]>) eirRecord.getRecord();
+        assertTrue(serviceData.containsKey(dataServiceUUID));
+        assertArrayEquals(new int[] {0x74, 0x01, 0x0d, 0x01, (byte) 0xec}, serviceData.get(dataServiceUUID));
+    }
+}


### PR DESCRIPTION
Hi @cdjackson, this PR is to add support for broadcast messages for service data. The messages are represented as Map<UUID, int[]>, where UUID is service UUID (16, 32 or 128 bits) and int[] is corresponding data.

I also slightly tweaked manufacturer data as well, now it is returned as Map<Short, int[]>, where key is manufacturer ID.