### PR TITLE
Multithreading improvements

### DIFF
--- a/com.zsmartsystems.bluetooth.bluegiga/src/main/java/com/zsmartsystems/bluetooth/bluegiga/BlueGigaSerialHandler.java
+++ b/com.zsmartsystems.bluetooth.bluegiga/src/main/java/com/zsmartsystems/bluetooth/bluegiga/BlueGigaSerialHandler.java
@@ -1,5 +1,8 @@
 package com.zsmartsystems.bluetooth.bluegiga;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -8,10 +11,14 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * The main handler class for interacting with the BlueGiga serial API. This class provides transaction management and
@@ -167,14 +174,22 @@ public class BlueGigaSerialHandler {
     }
 
     /**
-     * Requests parser thread to shutdown.
+     * Requests parser thread to shutdown. Waits forever while the parser thread is getting shut down.
      */
     public void close() {
+        close(0);
+    }
+
+    /**
+     * Requests parser thread to shutdown. Waits specified milliseconds while the parser thread is getting shut down.
+     * @param timeout milliseconds to wait
+     */
+    public void close(long timeout) {
         this.close = true;
         executor.shutdownNow();
         try {
             parserThread.interrupt();
-            parserThread.join();
+            parserThread.join(timeout);
         } catch (InterruptedException e) {
             logger.warn("Interrupted in packet parser thread shutdown join.");
         }
@@ -303,14 +318,15 @@ public class BlueGigaSerialHandler {
      *            Request {@link BlueGigaCommand}
      * @return response {@link Future} {@link BlueGigaResponse}
      */
-    public Future<BlueGigaResponse> sendBleRequestAsync(final BlueGigaCommand bleCommand) {
+    public <T extends BlueGigaResponse> Future<T> sendBleRequestAsync(final BlueGigaCommand bleCommand,
+                                                                      final Class<T> expected) {
         checkIfAlive();
-        class TransactionWaiter implements Callable<BlueGigaResponse>, BleListener {
-            private boolean complete = false;
-            private BlueGigaResponse response = null;
+        class TransactionWaiter implements Callable<T>, BleListener<T> {
+            private boolean complete;
+            private T response;
 
             @Override
-            public BlueGigaResponse call() {
+            public T call() {
                 // Register a listener
                 addTransactionListener(this);
 
@@ -335,9 +351,16 @@ public class BlueGigaSerialHandler {
             }
 
             @Override
-            public boolean transactionEvent(BlueGigaResponse bleResponse) {
+            public boolean transactionEvent(T bleResponse) {
                 // Check if this response completes our transaction
                 if (bleCommand.hashCode() == bleResponse.hashCode()) {
+                    return false;
+                }
+
+                if (!expected.isInstance(bleResponse)) {
+                    // ignoring response if it was not requested
+                    logger.warn("Ignoring {} response which has not been requested.",
+                            bleResponse.getClass().getSimpleName());
                     return false;
                 }
 
@@ -351,7 +374,7 @@ public class BlueGigaSerialHandler {
             }
         }
 
-        Callable<BlueGigaResponse> worker = new TransactionWaiter();
+        Callable<T> worker = new TransactionWaiter();
         return executor.submit(worker);
     }
 
@@ -365,7 +388,7 @@ public class BlueGigaSerialHandler {
      */
     public BlueGigaResponse sendTransaction(BlueGigaCommand bleCommand) {
         checkIfAlive();
-        Future<BlueGigaResponse> futureResponse = sendBleRequestAsync(bleCommand);
+        Future<BlueGigaResponse> futureResponse = sendBleRequestAsync(bleCommand, BlueGigaResponse.class);
         try {
             return futureResponse.get();
         } catch (InterruptedException | ExecutionException e) {
@@ -384,8 +407,9 @@ public class BlueGigaSerialHandler {
      * @return response {@link BlueGigaResponse}
      * @throws TimeoutException when specified timeout exceeds
      */
-    public BlueGigaResponse sendTransaction(BlueGigaCommand bleCommand, long timeout) throws TimeoutException {
-        Future<BlueGigaResponse> futureResponse = sendBleRequestAsync(bleCommand);
+    public <T extends BlueGigaResponse> T sendTransaction(BlueGigaCommand bleCommand, Class<T> expected, long timeout)
+            throws TimeoutException {
+        Future<T> futureResponse = sendBleRequestAsync(bleCommand, expected);
         try {
             return futureResponse.get(timeout, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException e) {
@@ -509,7 +533,7 @@ public class BlueGigaSerialHandler {
         }
     }
 
-    interface BleListener {
-        boolean transactionEvent(BlueGigaResponse bleResponse);
+    interface BleListener<T extends BlueGigaResponse> {
+        boolean transactionEvent(T bleResponse);
     }
 }


### PR DESCRIPTION
Hi @cdjackson, this PR is to fix some issues wth multithreading. 

1. Fixing BlueGigaSerialHandler initialisation process (waiting until the daemon thread kicks off, so that it can receive commands). This bug/defect happens when a client of BlueGigaSerialHandler tries to send any transaction right after BlueGigaSerialHandler constructor returns, the result - a timeout exception. The fix - just wait until the daemon thread kicks off.

2. Shutting down Executors service (to prevent daemon thread leaks) when BlueGiga handler gets closed. This bug/defect happens when a client closes BlueGigaSerialHandler which leads to the daemon thread to be hanging in memory forever. The fix - simply shut down the Executor service when closing.